### PR TITLE
chore: remove footer social links

### DIFF
--- a/index.html
+++ b/index.html
@@ -208,11 +208,13 @@
     <footer class="bg-white border-t border-slate-200">
       <div class="mx-auto max-w-7xl px-6 lg:px-8 py-10 flex flex-col md:flex-row items-center justify-between gap-4 text-sm text-slate-600">
         <div>© 2025 MEIBE Studio 梅設線創意工作室｜統一編號:00565039｜Taipei Taiwan</div>
+        <!--
         <div class="flex items-center gap-4">
           <a href="https://github.com/your-github" class="hover:text-brand" aria-label="GitHub">GitHub</a>
           <a href="https://www.instagram.com/你的帳號" class="hover:text-brand" aria-label="Instagram">Instagram</a>
           <a href="mailto:hello@example.com" class="hover:text-brand" aria-label="Email">Email</a>
         </div>
+        -->
       </div>
     </footer>
 


### PR DESCRIPTION
## Summary
- comment out footer social media links, leaving only copyright text

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b1e1f3e90c83269e73ff4f330936e7